### PR TITLE
pinning numpy version <2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ google-cloud-aiplatform==1.48.0
 hf_transfer==0.1.6
 litellm==1.35.18
 num2words==0.5.13
+numpy<2
 pandas==2.2.2
 pydantic==2.4.2
 pytest==8.1.1


### PR DESCRIPTION
benchmark runs were failing due to the release of numpy 2.0 so pinning to <2 to resolve